### PR TITLE
fix: Close the errors channel when a client disconnect occurs

### DIFF
--- a/pkg/client/nbd.go
+++ b/pkg/client/nbd.go
@@ -315,6 +315,10 @@ n:
 	}
 
 	go func() {
+		defer func() {
+			close(fatal)
+		}()
+
 		if _, _, err := syscall.Syscall(
 			syscall.SYS_IOCTL,
 			device.Fd(),


### PR DESCRIPTION
Fixes: https://github.com/pojntfx/go-nbd/issues/1