### PR TITLE
feat: Add ARM64 support for non-CGO Linux builds

### DIFF
--- a/pkg/ioctl/negotiation_go_arm64.go
+++ b/pkg/ioctl/negotiation_go_arm64.go
@@ -1,0 +1,13 @@
+//go:build linux && !cgo && arm64
+
+package ioctl
+
+// See /usr/include/linux/nbd.h
+
+const (
+	NEGOTIATION_IOCTL_SET_SOCK        = 43776
+	NEGOTIATION_IOCTL_SET_BLOCKSIZE   = 43777
+	NEGOTIATION_IOCTL_SET_SIZE_BLOCKS = 43783
+	NEGOTIATION_IOCTL_DO_IT           = 43779
+	NEGOTIATION_IOCTL_SET_TIMEOUT     = 43785
+)

--- a/pkg/ioctl/transmission_go_arm64.go
+++ b/pkg/ioctl/transmission_go_arm64.go
@@ -1,0 +1,9 @@
+//go:build linux && !cgo && arm64
+
+package ioctl
+
+const (
+	TRANSMISSION_IOCTL_DISCONNECT = 43784
+	TRANSMISSION_IOCTL_CLEAR_SOCK = 43780
+	TRANSMISSION_IOCTL_CLEAR_QUE  = 43781
+)


### PR DESCRIPTION
## Summary
- Add `negotiation_go_arm64.go` and `transmission_go_arm64.go` for ARM64 non-CGO Linux builds
- The ioctl constants are identical to AMD64 versions (architecture-independent Linux kernel ABI)
- Enables `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build` to work correctly

## Test plan
- [x] Verified `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./...` succeeds
- [x] Verified `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./...` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)